### PR TITLE
Remove old pledge form links

### DIFF
--- a/direct_give.html
+++ b/direct_give.html
@@ -191,7 +191,7 @@
             <hr>
             <div class="row" id="more-info">
                 <h2 class="text-center">How to Donate</h2>
-                <h4 class="indent">You may <a href="donations.html">donate online</a> through PayPal using your credit card, debit card or <b>PayPal</b> account or Download the <a href="pledgeform.html">Pledge Form</a> to pay by check. Please return this form along with your payment (payable to &quot;CLIPCO&quot;) to the Meyerholz office, your student&#39;s home room teacher or your CLIPCO grade.</h4>
+                <h4 class="indent">Please use the <a href="donations.html">online pledge form</a> for both donations by check or through PayPal using your credit card or debit card.</h4>
                 <h4 class="indent"><b>If you have more questions about the Direct Give Contest, please read our <a href="donateFAQ.html">FAQ</a>. If the information there does not answer your question, please contact your <a href="contact.html?show=board">CLIPCO grade representative.</a></b></h4>
                 <h4 class="indent">Please don&#39;t forget to potentially double your donation by applying for <b>corporate matching</b> through your employer. Corporate matching helps CLIPCO tremendously in making up for donation shortfalls. Every year, the corporate match donations to CLIPCO contribute between 15-25% of our annual budget. Please see <a href="donateFAQ.html#corporate-matching-scroll">How do I get corporate matching for my donation?</a> for more information.
                 </h4>

--- a/donations.html
+++ b/donations.html
@@ -84,24 +84,25 @@
             <div class="col-sm-8 col-xs-12">
                 <h2>Funding CLIPCO</h2>
                 <h4>CLIP depends completely on donations to fund the programs not covered by normal school district funds.
-                    These programs include the Mandarin
-                    <br>Chinese curriculum, CLIP Art program, and Homework Club to name a few. To support these programs,
-                    CLIPCO hosts the <a href="direct_give.html">Direct Give Contest</a>
-                    <br>to garner donations. To foster friendly competition and to encourage donations, CLIPCO is offering
+                    These programs include the Mandarin Chinese curriculum, CLIP Art program, and Homework Club to name a few.
+                    <br><br>
+                    To support these programs, CLIPCO hosts the <a href="direct_give.html">Direct Give Contest</a>
+                    to garner donations. 
+                    <br><br>
+                    To foster friendly competition and to encourage donations, CLIPCO is offering
                     several <a href="direct_give.html#prizes">prizes</a> to those who donate.
                 </h4>
                 <br>
                 <h2>Online Pledge Form</h2>
                 <h4>
-                    Please use the online pledge form below for both check and PayPal donations.
-                    <br>
-                    For questions about your donations, please contact our Treasurer(s) at donate@cusdclipco.org.
-                    <br>
+                    Please use the online pledge form below for both check and PayPal donations. 
+                    <br><br>
+                    If paying by check, please return a print out of your email confirmation along with your payment to the 
+                    Meyerholz office. Please make checks payable to &quot;CLIPCO&quot;)and include your student&#39;s grade 
+                    and room number on the check.
+                    <br><br>
                     Thank you for your support in the continuing success of CLIP!
-                    <br>
-                    <a href="donateFAQ.html">Donations FAQ</a>
                 </h4>
-                <h4>To pay by check, download and fill out the <a href="pledgeform.html">pledge form</a>.</h4>
                 <br>
             </div>
             <div class="col-sm-4 col-xs-12" id="stock-image">
@@ -115,6 +116,9 @@
                 </div>
             </div>
         </div>
+		<br><br>
+		For questions about your donations, please contact our treasurer at treasurer@cusdclipco.org or refer to 
+		our <a href="donateFAQ.html">Donations FAQ</a>.
         <footer class="text-center bg-grey">
             <a href="#top" title="To Top"><span class="glyphicon glyphicon-chevron-up"></span></a>
         </footer>


### PR DESCRIPTION
Removed links to the paper pledge form. Changed verbiage to redirect to the online pledge form.

Fixed some formatting in the "Funding CLIPCO" section.